### PR TITLE
Setup vitest and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,12 @@ TypesScript
 
 Tailwindcss
 
+## Tests
+
+Para ejecutar las pruebas unitarias, utiliza el siguiente comando:
+
+```bash
+npm test
+```
+
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.3",
@@ -28,6 +29,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/services/functions.test.ts
+++ b/src/services/functions.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { generateUniqueIndex } from './functions'
+
+describe('generateUniqueIndex', () => {
+  it('returns a number within the valid range', () => {
+    const dataLength = 10
+    const index = generateUniqueIndex(dataLength, 5)
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(index).toBeLessThan(dataLength)
+  })
+
+  it('never returns the previous index', () => {
+    const dataLength = 10
+    const previousIndex = 3
+    for (let i = 0; i < 100; i++) {
+      expect(generateUniqueIndex(dataLength, previousIndex)).not.toBe(previousIndex)
+    }
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'node',
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest for testing
- add script to run tests
- add basic unit tests for `generateUniqueIndex`
- document how to run the tests in README

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840000563a88323a7255ae5c0685148