### PR TITLE
Fix audio listener cleanup

### DIFF
--- a/src/hooks/useSelectQuiz.ts
+++ b/src/hooks/useSelectQuiz.ts
@@ -33,6 +33,9 @@ const useSelectQuiz = () => {
       setIsSongPlaying(false);
     };
     initialSong.addEventListener('ended', handleSongEnded);
+    return () => {
+      initialSong.removeEventListener('ended', handleSongEnded);
+    };
   }, [initialSong, setIsSongPlaying]);
 
   return {


### PR DESCRIPTION
## Summary
- fix missing cleanup for audio ended event listener

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build` *(fails: TypeScript errors due to missing React types)*

------
https://chatgpt.com/codex/tasks/task_e_683ffde174648323a854cf0a4e6837c9